### PR TITLE
Update main.go

### DIFF
--- a/cshared/main.go
+++ b/cshared/main.go
@@ -45,24 +45,36 @@ var Version = "dev"
 
 // If ECP Logging is enabled return true
 // Otherwise return false
-func enableECPLogging() bool {
-	if os.Getenv("ENABLE_ENTERPRISE_CERTIFICATE_LOGS") != "" {
+func enabledECPLogging() bool {
+  if os.Getenv("ENABLE_ENTERPRISE_CERTIFICATE_LOGS") != "" {
 		return true
 	}
 
-	log.SetOutput(io.Discard)
 	return false
 }
+
+func ecpLogf(format string, v ...any) {
+	if enabledECPLogging() {
+		log.Printf(format, v...)
+	}
+}
+
+func ecpPrint(v any) {
+	if enabledECPLogging() {
+		log.Print(v)
+	}
+}
+
 
 func getCertPem(configFilePath string) []byte {
 	key, err := client.Cred(configFilePath)
 	if err != nil {
-		log.Printf("Could not create client using config %s: %v", configFilePath, err)
+		ecpLogf("Could not create client using config %s: %v", configFilePath, err)
 		return nil
 	}
 	defer func() {
 		if err = key.Close(); err != nil {
-			log.Printf("Failed to clean up key. %v", err)
+			ecpLogf("Failed to clean up key. %v", err)
 		}
 	}()
 
@@ -91,7 +103,6 @@ func ECPVersion() *C.char {
 //
 //export GetCertPem
 func GetCertPem(configFilePath *C.char, certHolder *byte, certHolderLen int) int {
-	enableECPLogging()
 	pemBytes := getCertPem(C.GoString(configFilePath))
 	if certHolder != nil {
 		cert := unsafe.Slice(certHolder, certHolderLen)
@@ -120,15 +131,14 @@ func GetCertPemForPython(configFilePath *C.char, certHolder *byte, certHolderLen
 //export Sign
 func Sign(configFilePath *C.char, digest *byte, digestLen int, sigHolder *byte, sigHolderLen int) int {
 	// First create a handle around the specified certificate and private key.
-	enableECPLogging()
 	key, err := client.Cred(C.GoString(configFilePath))
 	if err != nil {
-		log.Printf("Could not create client using config %s: %v", C.GoString(configFilePath), err)
+		ecpLogf("Could not create client using config %s: %v", C.GoString(configFilePath), err)
 		return 0
 	}
 	defer func() {
 		if err = key.Close(); err != nil {
-			log.Printf("Failed to clean up key. %v", err)
+			ecpLogf("Failed to clean up key. %v", err)
 		}
 	}()
 	var isRsa bool
@@ -138,9 +148,9 @@ func Sign(configFilePath *C.char, digest *byte, digestLen int, sigHolder *byte, 
 		log.Print("the key is ecdsa key")
 	case *rsa.PublicKey:
 		isRsa = true
-		log.Print("the key is rsa key")
+		ecpLogf("the key is rsa key")
 	default:
-		log.Printf("unsupported key type")
+		ecpLogf("unsupported key type")
 		return 0
 	}
 
@@ -160,11 +170,11 @@ func Sign(configFilePath *C.char, digest *byte, digestLen int, sigHolder *byte, 
 		signature, signErr = key.Sign(nil, digestSlice, crypto.SHA256)
 	}
 	if signErr != nil {
-		log.Printf("failed to sign hash: %v", signErr)
+		ecpLogf("failed to sign hash: %v", signErr)
 		return 0
 	}
 	if sigHolderLen < len(signature) {
-		log.Printf("The sigHolder buffer size %d is smaller than the signature size %d", sigHolderLen, len(signature))
+		ecpLogf("The sigHolder buffer size %d is smaller than the signature size %d", sigHolderLen, len(signature))
 		return 0
 	}
 
@@ -191,12 +201,12 @@ func SignForPython(configFilePath *C.char, digest *byte, digestLen int, sigHolde
 func GetKeyType(configFilePath *C.char) *C.char {
 	key, err := client.Cred(C.GoString(configFilePath))
 	if err != nil {
-		log.Printf("Could not create client using config %s: %v", C.GoString(configFilePath), err)
+		ecpLogf("Could not create client using config %s: %v", C.GoString(configFilePath), err)
 		return C.CString("unknown")
 	}
 	defer func() {
 		if err = key.Close(); err != nil {
-			log.Printf("Failed to clean up key. %v", err)
+			ecpLogf("Failed to clean up key. %v", err)
 		}
 	}()
 	switch key.Public().(type) {


### PR DESCRIPTION
This change introduces wrapper functions (ecpLogf, ecpPrint, ecpFatalln, ecpFatalf) that check the ENABLE_ENTERPRISE_CERTIFICATE_LOGS environment variable before writing to the log. This prevents unnecessary calls to log.SetOutput(io.Discard) and ensures that logging is consistently gated by the environment variable. The enableECPLogging function has been renamed to enabledECPLogging for clarity.